### PR TITLE
feat: level 3 - rework the calculator component

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Run `npm run start` for a dev server. Navigate to `http://localhost:4200/`.
 
 Then you can play with it to test different cases
 
+## Level-3
+
+- Rework `CalculatorComponent`, by implementing the `ControlValueAccessor` interface and its methods.
+- Move the `shopId` from `calculator.service` to a from entry, so it can be changed directly from the select box in the form.
+- Make `shopId` as an input for the `CalculatorComponent`
+- Since the available shop is only number 5, the `CalculatorComponent` is disabled when the selected store is another value rather than 5.
+- Improve the display of card by adding `cardFormatPipe`
+- Now, the `search` button is only enabled when the value of the input is changed, so the user cannot send multiple requests for the same amount.
+- Rename same variables
+- Change detection strategy of the `AppComponent` to OnPush.
+- Some css changes
+
 ## Note
 
-URL and shopId can be easily changed in the application from `calculator.service.ts` file
+URL can be easily changed in the application from `calculator.service.ts` file

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Then you can play with it to test different cases
 - Rename same variables
 - Change detection strategy of the `AppComponent` to OnPush.
 - Some css changes
+- Add `calculatorValidator` as a validator for the calculator form, so we're able to disabled the `buy` button when the parent form is not valid e.g: cards is empty `{value:5, cards:[]}`
 
 ## Note
 

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -8,6 +8,25 @@ header {
 
 main {
   min-height: 80vh;
+  text-align: center;
+}
+
+.form-container {
+  margin-top: 36px;
+}
+
+.shop-select,
+.btn-buy {
+  height: 26px;
+}
+
+.btn-buy {
+  margin-top: 24px;
+  width: 130px;
+}
+
+.shop-select {
+  width: 200px;
 }
 
 footer {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,11 @@
 <header>Welcome to Glady store</header>
 <main>
-  <app-calculator
-    (enteredAmount)="handleCalculatorEvent($event)"
-  ></app-calculator>
+  <form [formGroup]="calculatorForm">
+    <app-calculator
+      (enteredAmount)="handleCalculatorEvent($event)"
+      formControlName="calculator"
+    >
+    </app-calculator>
+  </form>
 </main>
 <footer>Hafid © 2023</footer>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -23,7 +23,13 @@
       formControlName="calculator"
     >
     </app-calculator>
-    <button type="submit" class="btn-buy" [disabled]="isDisabled">Buy</button>
+    <button
+      type="submit"
+      class="btn-buy"
+      [disabled]="calculatorForm.invalid || isDisabled"
+    >
+      Buy
+    </button>
   </form>
 </main>
 <footer>Hafid © 2023</footer>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,29 @@
 <header>Welcome to Glady store</header>
 <main>
-  <form [formGroup]="calculatorForm">
+  <form
+    class="form-container"
+    [formGroup]="calculatorForm"
+    (ngSubmit)="onSubmit()"
+  >
+    <label for="shop-select">Choose a shop: </label>
+    <select
+      id="shop-select"
+      class="shop-select"
+      formControlName="shopSelect"
+      (change)="changeShop()"
+    >
+      <option value="">Please choose your shop</option>
+      <option *ngFor="let shop of shopsList" [ngValue]="shop">
+        {{ shop }}
+      </option>
+    </select>
     <app-calculator
+      [shopId]="selectedShop"
       (enteredAmount)="handleCalculatorEvent($event)"
       formControlName="calculator"
     >
     </app-calculator>
+    <button type="submit" class="btn-buy" [disabled]="isDisabled">Buy</button>
   </form>
 </main>
 <footer>Hafid © 2023</footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,15 +1,27 @@
+import { CalculatorComponentValue } from './model/calculatorComponentValue';
 import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CalculatorComponent } from './components/calculator/calculator.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CalculatorComponent],
+  imports: [CalculatorComponent, ReactiveFormsModule],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
   title = 'glady-store-front';
+
+  private readonly initialValue: CalculatorComponentValue = {
+    value: 42,
+    cards: [20, 22],
+  };
+
+  protected readonly calculatorForm = new FormGroup({
+    calculator: new FormControl<CalculatorComponentValue>(this.initialValue),
+  });
+
   constructor() {}
 
   protected handleCalculatorEvent(amount: number) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,30 +1,69 @@
+import { CommonModule } from '@angular/common';
 import { CalculatorComponentValue } from './model/calculatorComponentValue';
 import { Component } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { CalculatorComponent } from './components/calculator/calculator.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CalculatorComponent, ReactiveFormsModule],
+  imports: [
+    CalculatorComponent,
+    FormsModule,
+    CommonModule,
+    ReactiveFormsModule,
+  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
   title = 'glady-store-front';
-
+  
   private readonly initialValue: CalculatorComponentValue = {
     value: 42,
     cards: [20, 22],
   };
 
-  protected readonly calculatorForm = new FormGroup({
-    calculator: new FormControl<CalculatorComponentValue>(this.initialValue),
-  });
+  protected readonly shopsList = [1, 2, 3, 4, 5];
+  protected readonly availableShop = 5;
 
-  constructor() {}
+  protected isDisabled = false;
+
+  protected readonly calculatorForm;
+
+  constructor() {
+
+    this.calculatorForm = new FormGroup({
+      shopSelect: new FormControl<number>(5, Validators.required),
+      calculator: new FormControl<CalculatorComponentValue>(this.initialValue),
+    });
+  }
 
   protected handleCalculatorEvent(amount: number) {
     console.log('The entered amount is:', amount);
+  }
+
+  protected changeShop() {
+    if (this.selectedShop === this.availableShop) {
+      this.calculatorForm.get('calculator')?.enable();
+      this.isDisabled = false;
+    } else {
+      this.calculatorForm.get('calculator')?.disable();
+      this.isDisabled = true;
+    }
+  }
+
+  protected onSubmit() {
+    console.log('Congrats! your purchase has been saved!');
+  }
+
+  get selectedShop(): number {
+    return this.calculatorForm.get('shopSelect')?.value as number;
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,10 @@
 import {
+  Component,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
-  Component,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CalculatorComponentValue } from './model/calculatorComponentValue';
-import { Component } from '@angular/core';
 import {
   FormControl,
   FormGroup,
@@ -30,7 +29,7 @@ import { CalculatorComponent } from './components/calculator/calculator.componen
 })
 export class AppComponent {
   title = 'glady-store-front';
-  
+
   private readonly initialValue: CalculatorComponentValue = {
     value: 42,
     cards: [20, 22],

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,3 +1,8 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CalculatorComponentValue } from './model/calculatorComponentValue';
 import { Component } from '@angular/core';
@@ -21,6 +26,7 @@ import { CalculatorComponent } from './components/calculator/calculator.componen
   ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
   title = 'glady-store-front';
@@ -37,8 +43,7 @@ export class AppComponent {
 
   protected readonly calculatorForm;
 
-  constructor() {
-
+  constructor(private readonly cd: ChangeDetectorRef) {
     this.calculatorForm = new FormGroup({
       shopSelect: new FormControl<number>(5, Validators.required),
       calculator: new FormControl<CalculatorComponentValue>(this.initialValue),
@@ -57,6 +62,7 @@ export class AppComponent {
       this.calculatorForm.get('calculator')?.disable();
       this.isDisabled = true;
     }
+    this.cd.markForCheck();
   }
 
   protected onSubmit() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,6 +13,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { CalculatorComponent } from './components/calculator/calculator.component';
+import { calculatorValidator } from './validators/calculator';
 
 @Component({
   selector: 'app-root',
@@ -32,7 +33,7 @@ export class AppComponent {
 
   private readonly initialValue: CalculatorComponentValue = {
     value: 42,
-    cards: [20, 22],
+    cards: [22, 20],
   };
 
   protected readonly shopsList = [1, 2, 3, 4, 5];
@@ -45,7 +46,10 @@ export class AppComponent {
   constructor(private readonly cd: ChangeDetectorRef) {
     this.calculatorForm = new FormGroup({
       shopSelect: new FormControl<number>(5, Validators.required),
-      calculator: new FormControl<CalculatorComponentValue>(this.initialValue),
+      calculator: new FormControl<CalculatorComponentValue>(this.initialValue, [
+        Validators.required,
+        calculatorValidator(),
+      ]),
     });
   }
 

--- a/src/app/calculator.service.ts
+++ b/src/app/calculator.service.ts
@@ -3,8 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { catchError, EMPTY, Observable } from 'rxjs';
 import { ICombinations } from './model/combinations';
 
-const shopId = 5;
-const shopUrl = `http://localhost:3000/shop/${shopId}/search-combination`;
+const shopUrl = `http://localhost:3000/shop/`;
 
 @Injectable()
 export class CalculatorService {
@@ -16,16 +15,10 @@ export class CalculatorService {
 
   constructor(private http: HttpClient) {}
 
-  searchCards(amount: number): Observable<ICombinations> {
-    return this.http
-      .get<any>(`${shopUrl}/?amount=${amount}`, this.httpOptions)
-      .pipe(
-        catchError((err) => {
-          // as I don't have an error handling service, I just log the error in the console.
-          // but normally I have to display this error to the user in the appropriate place, e.g: toast.
-          console.error(`I caught ${err.message}`);
-          return EMPTY;
-        })
-      );
+  searchCards(amount: number, shopId: number): Observable<ICombinations> {
+    return this.http.get<any>(
+      `${shopUrl}${shopId}/search-combination/?amount=${amount}`,
+      this.httpOptions
+    );
   }
 }

--- a/src/app/components/calculator/calculator.component.css
+++ b/src/app/components/calculator/calculator.component.css
@@ -1,6 +1,5 @@
 .calculator-container {
-  text-align: center;
-  margin-top: 50px;
+  margin-top: 24px;
 }
 
 .form-container {

--- a/src/app/components/calculator/calculator.component.css
+++ b/src/app/components/calculator/calculator.component.css
@@ -34,10 +34,6 @@
   color: #007fc9;
 }
 
-.card::after {
-  content: "$";
-}
-
 p {
   font-size: large;
 }

--- a/src/app/components/calculator/calculator.component.html
+++ b/src/app/components/calculator/calculator.component.html
@@ -1,16 +1,28 @@
 <div class="calculator-container">
-  <form class="form-container" [formGroup]="shopForm" (ngSubmit)="onSubmit()">
+  <div class="form-container">
     <input
       id="amount-input"
       class="amount-input"
       type="number"
       placeholder="Enter your amount"
-      formControlName="amount"
+      min="0"
+      [disabled]="isDisabled"
+      [(ngModel)]="amount"
+      (ngModelChange)="handleValueChanges($event)"
     />
-    <button type="submit" [disabled]="shopForm.invalid || isLoading">
+    <!-- The 'search' button will be disabled while:
+         - the input is not valid, 
+         - the calculator form is disabled via reactive Form,
+         - fetching data
+         - the input's value hasn't been modified-->
+    <button
+      type="button"
+      (click)="onClick()"
+      [disabled]="!isValid || isDisabled || isLoading || !isModified"
+    >
       Search
     </button>
-  </form>
+  </div>
   <div class="suggestion-container">
     <button
       class="btn-suggest"
@@ -23,7 +35,7 @@
     <button
       class="btn-suggest"
       type="button"
-      [disabled]="!higherSuggestion || amount === higherSuggestion"
+      [disabled]="!higherSuggestion || higherSuggestion === amount"
       (click)="increase()"
     >
       +
@@ -38,7 +50,7 @@
       another one.
     </p>
     <span class="card" *ngFor="let card of cards; trackBy: trackByFn">
-      {{ card }}
+      {{ card | cardFormat : "$" }}
     </span>
   </div>
 </div>

--- a/src/app/components/calculator/calculator.component.html
+++ b/src/app/components/calculator/calculator.component.html
@@ -27,7 +27,7 @@
     <button
       class="btn-suggest"
       type="button"
-      [disabled]="!lowerSuggestion || lowerSuggestion === amount"
+      [disabled]="!lowerAmount || lowerAmount === amount"
       (click)="decrease()"
     >
       -
@@ -35,7 +35,7 @@
     <button
       class="btn-suggest"
       type="button"
-      [disabled]="!higherSuggestion || higherSuggestion === amount"
+      [disabled]="!higherAmount || higherAmount === amount"
       (click)="increase()"
     >
       +
@@ -45,7 +45,7 @@
     <p *ngIf="cards.length !== 0">
       Your amount is composed of the following cards:
     </p>
-    <p *ngIf="lowerSuggestion || higherSuggestion">
+    <p *ngIf="lowerAmount || higherAmount">
       Sorry, we couldn't find a combination for your amount, please select
       another one.
     </p>

--- a/src/app/components/calculator/calculator.component.ts
+++ b/src/app/components/calculator/calculator.component.ts
@@ -91,6 +91,8 @@ export class CalculatorComponent implements ControlValueAccessor {
             this.higherAmount = combinations.ceil?.value ?? null;
             this.lowerAmount = combinations.floor?.value ?? null;
           }
+          // Notify the parent form that a new value is available
+          this.onChange({ value: this.amount!, cards: this.cards });
           this.cd.markForCheck();
         },
         error: (err) => {

--- a/src/app/components/calculator/calculator.component.ts
+++ b/src/app/components/calculator/calculator.component.ts
@@ -41,8 +41,8 @@ export class CalculatorComponent implements ControlValueAccessor {
 
   private amountInput: Nullable<number> = null;
 
-  protected higherSuggestion: Nullable<number> = null;
-  protected lowerSuggestion: Nullable<number> = null;
+  protected higherAmount: Nullable<number> = null;
+  protected lowerAmount: Nullable<number> = null;
   protected cards: Array<number> = [];
   protected isLoading = false;
   protected isDisabled = false;
@@ -83,8 +83,8 @@ export class CalculatorComponent implements ControlValueAccessor {
         if (combinations.equal) {
           this.cards = combinations.equal.cards;
         } else {
-          this.higherSuggestion = combinations.ceil?.value ?? null;
-          this.lowerSuggestion = combinations.floor?.value ?? null;
+          this.higherAmount = combinations.ceil?.value ?? null;
+          this.lowerAmount = combinations.floor?.value ?? null;
         }
         this.cd.markForCheck();
       });
@@ -99,12 +99,12 @@ export class CalculatorComponent implements ControlValueAccessor {
 
   protected increase() {
     this.isModified = true;
-    this.amount = this.higherSuggestion;
+    this.amount = this.higherAmount;
   }
 
   protected decrease() {
     this.isModified = true;
-    this.amount = this.lowerSuggestion;
+    this.amount = this.lowerAmount;
   }
 
   protected trackByFn(index: number): number {
@@ -117,8 +117,8 @@ export class CalculatorComponent implements ControlValueAccessor {
 
   private reset(): void {
     this.cards = [];
-    this.lowerSuggestion = null;
-    this.higherSuggestion = null;
+    this.lowerAmount = null;
+    this.higherAmount = null;
     this.isModified = false;
   }
 

--- a/src/app/components/calculator/calculator.component.ts
+++ b/src/app/components/calculator/calculator.component.ts
@@ -1,62 +1,83 @@
+import { CalculatorComponentValue } from './../../model/calculatorComponentValue';
 import {
   ChangeDetectionStrategy,
   Component,
   ChangeDetectorRef,
   Output,
   EventEmitter,
+  forwardRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import {
-  ReactiveFormsModule,
-  FormGroup,
-  FormControl,
-  Validators,
+  NG_VALUE_ACCESSOR,
+  ControlValueAccessor,
+  FormsModule,
 } from '@angular/forms';
+import { take } from 'rxjs';
 import { CalculatorService } from '../../calculator.service';
 import { Nullable } from '../../helpers/types';
+import { CardFormatPipe } from '../../pipes/card-format.pipe';
 
 @Component({
   selector: 'app-calculator',
   standalone: true,
-  imports: [HttpClientModule, ReactiveFormsModule, CommonModule],
-  providers: [CalculatorService],
+  imports: [HttpClientModule, FormsModule, CommonModule, CardFormatPipe],
+  providers: [
+    CalculatorService,
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: forwardRef(() => CalculatorComponent),
+    },
+  ],
   templateUrl: './calculator.component.html',
   styleUrls: ['./calculator.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CalculatorComponent {
+export class CalculatorComponent implements ControlValueAccessor {
   @Output()
   enteredAmount = new EventEmitter<number>();
 
-  protected readonly shopForm = new FormGroup({
-    amount: new FormControl<number | null>(null, [
-      Validators.required,
-      Validators.min(0),
-    ]),
-  });
+  private amountInput: Nullable<number> = null;
 
-  protected cards: Array<number> = [];
   protected higherSuggestion: Nullable<number> = null;
   protected lowerSuggestion: Nullable<number> = null;
+  protected cards: Array<number> = [];
   protected isLoading = false;
-
-  get amount() {
-    return this.shopForm.get('amount')?.value;
-  }
+  protected isDisabled = false;
+  protected isValid = false;
+  protected isModified = false;
 
   constructor(
     private readonly calculatorService: CalculatorService,
     private readonly cd: ChangeDetectorRef
-  ) {
-    this.shopForm.get('amount')?.valueChanges.subscribe((x) => console.log(x));
+  ) {}
+
+  public writeValue(calculatorComponentValue: CalculatorComponentValue): void {
+    const { value, cards } = calculatorComponentValue;
+    this.amount = value;
+    this.cards = cards;
   }
 
-  protected onSubmit(): void {
-    if (this.shopForm.invalid || !this.amount) return;
+  public registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  public registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  public setDisabledState?(isDisabled: boolean): void {
+    this.isDisabled = isDisabled;
+  }
+
+  protected onClick(): void {
+    if (!this.amount) return;
     this.isLoading = true;
     this.calculatorService
       .searchCards(this.amount)
+      .pipe(take(1))
       .subscribe((combinations) => {
         this.isLoading = false;
         if (combinations.equal) {
@@ -71,21 +92,41 @@ export class CalculatorComponent {
     this.enteredAmount.emit(this.amount);
   }
 
+  protected handleValueChanges($event: number): void {
+    this.isModified = true;
+    this.isValid = $event > 0;
+  }
+
   protected increase() {
-    this.shopForm.get('amount')?.patchValue(this.higherSuggestion);
+    this.isModified = true;
+    this.amount = this.higherSuggestion;
   }
 
   protected decrease() {
-    this.shopForm.get('amount')?.patchValue(this.lowerSuggestion);
+    this.isModified = true;
+    this.amount = this.lowerSuggestion;
   }
 
   protected trackByFn(index: number): number {
     return index;
   }
 
+  private onChange(value: CalculatorComponentValue): void {}
+
+  private onTouched(): void {}
+
   private reset(): void {
     this.cards = [];
     this.lowerSuggestion = null;
     this.higherSuggestion = null;
+    this.isModified = false;
+  }
+
+  get amount() {
+    return this.amountInput;
+  }
+
+  set amount(value: Nullable<number>) {
+    this.amountInput = value;
   }
 }

--- a/src/app/model/calculatorComponentValue.ts
+++ b/src/app/model/calculatorComponentValue.ts
@@ -1,0 +1,4 @@
+export interface CalculatorComponentValue {
+  value: number;
+  cards: number[];
+}

--- a/src/app/pipes/card-format.pipe.ts
+++ b/src/app/pipes/card-format.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/*
+ * Displays the value with unit
+ * Takes an unit argument that defaults to $.
+ * Usage:
+ *   value | CardFormat:unit
+ * Example:
+ *   {{ 50 | cardFormat:'€' }}
+ *   formats to: 50 €
+ */
+@Pipe({ name: 'cardFormat', standalone: true })
+export class CardFormatPipe implements PipeTransform {
+  transform(value: number, unit = '$'): string {
+    return `${value} ${unit}`;
+  }
+}

--- a/src/app/validators/calculator.ts
+++ b/src/app/validators/calculator.ts
@@ -1,0 +1,14 @@
+import { AbstractControl, ValidatorFn, ValidationErrors } from '@angular/forms';
+import { CalculatorComponentValue } from './../model/calculatorComponentValue';
+
+export const calculatorValidator = (): ValidatorFn => {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const { value, cards }: CalculatorComponentValue = control.value;
+    if (!value || value < 0) {
+      return { calculatorValueInvalid: true };
+    } else if (cards.length === 0) {
+      return { calculatorCardsInvalid: true };
+    }
+    return null;
+  };
+};


### PR DESCRIPTION
This PR has as purpose to refactor the `CalculatorComponent` so it can be used in any reactive form.

## Major changes

- Rework `CalculatorComponent`, by implementing the `ControlValueAccessor` interface and its methods.
- Move the `shopId` from `calculator.service` to a from entry, so it can be changed directly from the select box in the form.
- Make `shopId` as an input for the `CalculatorComponent`
- Since the available shop is only number 5, the `CalculatorComponent` is disabled when the selected store is another value rather than 5.
- Improve the display of card by adding `cardFormatPipe`
- Now, the `search` button is only enabled when the value of the input is changed, so the user cannot send multiple requests for the same amount.
- Rename same variables
- Change detection strategy of the `AppComponent` to OnPush.
- Some css changes
- Add `calculatorValidator` as a validator for the calculator form, so we're able to disable the `buy` button when the parent form is not valid e.g: cards is empty `{value:5, cards:[]}`